### PR TITLE
if defined(__cplusplus) for xpum_vgpu_precheck_result_t default const…

### DIFF
--- a/core/include/xpum_structs.h
+++ b/core/include/xpum_structs.h
@@ -1078,11 +1078,13 @@ typedef struct {
 } xpum_sensor_reading_t;
 
 typedef struct xpum_vgpu_precheck_result_t {
+#if defined(__cplusplus)
     xpum_vgpu_precheck_result_t(): vmxFlag(false), iommuStatus(false), sriovStatus(false) {
         vmxMessage[0] = 0;
         iommuMessage[0] = 0;
         sriovMessage[0] = 0;
     }
+#endif
     bool vmxFlag;                           ///< VMX flag
     bool iommuStatus;                       ///< IOMMU status flag
     bool sriovStatus;                       ///< SR-IOV status flag


### PR DESCRIPTION
Default constructor not valid for C compilation and should be protected by `if defined(__cplusplus)`.